### PR TITLE
Add Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ func main() {
 
 	response := mock.NewResponseBuilder(http.StatusOK).AddBody(`{"status": "OK"}`).Build()
 	
-	limit := mock.NewMockCallLimit(3)
-
-	mockDefinition := mock.NewDefinition(request, response, limit)
+	mockDefinition := mock.NewDefinition(request, response)
 
 	err = instance.AddMock(mockDefinition)
 	if err != nil {
@@ -91,10 +89,10 @@ response := mock.NewResponseBuilder(http.StatusOK).
     AddHeader("Content-Type", "application/json").
     Build()
 
-mockDefinition := mock.NewDefinition(request, response, nil)
+mockDefinition := mock.NewDefinition(request, response)
 ```
 
-You can also include a limit on how many times a mock can be called using the `NewMockCallLimit` function.
+You can also include a limit on how many times a mock can be called using the `WithCallLimit` option function.
 
 ```go
 request := mock.NewRequestBuilder(http.MethodPut, "/foo/bar").
@@ -110,9 +108,7 @@ AddBody(`{"status": "OK"}`).
 AddHeader("Content-Type", "application/json").
 Build()
 
-limit := mock.NewMockCallLimit(5)
-
-mockDefinition := mock.NewDefinition(request, response, limit)
+mockDefinition := mock.NewDefinition(request, response, mock.WithCallLimit(3))
 ```
 
 ### Raw Json

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ func main() {
 		Build()
 
 	response := mock.NewResponseBuilder(http.StatusOK).AddBody(`{"status": "OK"}`).Build()
+	
+	limit := mock.NewMockCallLimit(3)
 
-	mockDefinition := mock.NewDefinition(request, response)
+	mockDefinition := mock.NewDefinition(request, response, limit)
 
 	err = instance.AddMock(mockDefinition)
 	if err != nil {
@@ -89,7 +91,28 @@ response := mock.NewResponseBuilder(http.StatusOK).
     AddHeader("Content-Type", "application/json").
     Build()
 
-mockDefinition := mock.NewDefinition(request, response)
+mockDefinition := mock.NewDefinition(request, response, nil)
+```
+
+You can also include a limit on how many times a mock can be called using the `NewMockCallLimit` function.
+
+```go
+request := mock.NewRequestBuilder(http.MethodPut, "/foo/bar").
+AddQueryParam("limit", "10").
+AddQueryParam("filters", "red", "green").
+AddHeader("Content-Type", "application/json", "application/vnd.api+json").
+AddBearerAuthToken("sv2361fr1o8ph3oin").
+AddJsonBody(`{"example": "body"`).
+Build()
+
+response := mock.NewResponseBuilder(http.StatusOK).
+AddBody(`{"status": "OK"}`).
+AddHeader("Content-Type", "application/json").
+Build()
+
+limit := mock.NewMockCallLimit(5)
+
+mockDefinition := mock.NewDefinition(request, response, limit)
 ```
 
 ### Raw Json

--- a/examples/createmock.go
+++ b/examples/createmock.go
@@ -30,9 +30,7 @@ func main() {
 
 	response := mock.NewResponseBuilder(http.StatusOK).AddBody(`{"status": "OK"}`).Build()
 
-	limit := mock.NewMockCallLimit(3)
-
-	mockDefinition := mock.NewDefinition(request, response, limit)
+	mockDefinition := mock.NewDefinition(request, response)
 
 	err = instance.AddMock(mockDefinition)
 	if err != nil {

--- a/examples/createmock.go
+++ b/examples/createmock.go
@@ -30,7 +30,9 @@ func main() {
 
 	response := mock.NewResponseBuilder(http.StatusOK).AddBody(`{"status": "OK"}`).Build()
 
-	mockDefinition := mock.NewDefinition(request, response)
+	limit := mock.NewMockCallLimit(3)
+
+	mockDefinition := mock.NewDefinition(request, response, limit)
 
 	err = instance.AddMock(mockDefinition)
 	if err != nil {

--- a/mock/context.go
+++ b/mock/context.go
@@ -1,5 +1,13 @@
 package mock
 
-func NewMockCallLimit(t int) *Context {
-	return &Context{Times: t}
+type ContextOption func(context *Context) *Context
+
+func WithCallLimit(times int) ContextOption {
+	return func(context *Context) *Context {
+		if context == nil {
+			context = &Context{}
+		}
+		context.Times = times
+		return context
+	}
 }

--- a/mock/context.go
+++ b/mock/context.go
@@ -1,0 +1,5 @@
+package mock
+
+func NewMockCallLimit(t int) *Context {
+	return &Context{Times: t}
+}

--- a/mock/context_test.go
+++ b/mock/context_test.go
@@ -1,0 +1,15 @@
+package mock_test
+
+import (
+	"github.com/churmd/smockerclient/mock"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewMockCallLimit(t *testing.T) {
+	expectedContext := &mock.Context{Times: 3}
+
+	actualContext := mock.NewMockCallLimit(3)
+
+	assert.Equal(t, expectedContext, actualContext)
+}

--- a/mock/context_test.go
+++ b/mock/context_test.go
@@ -1,15 +1,35 @@
 package mock_test
 
-//func TestWithMockCallLimit(t *testing.T) {
-//	req := createRequest()
-//	res := createResponse()
-//	def := mock.NewDefinition(req, res, mock.WithCallLimit(3))
-//
-//	expectedDef := mock.Definition{
-//		Request:  req,
-//		Response: res,
-//		Context:  &mock.Context{Times: 3},
-//	}
-//
-//	assert.Equal(t, expectedDef, def)
-//}
+import (
+	"github.com/churmd/smockerclient/mock"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWithCallLimit(t *testing.T) {
+	t.Run("it creates a new context with the times key if one doesnt exist", func(t *testing.T) {
+		req := createRequest()
+		res := createResponse()
+		def := mock.NewDefinition(req, res, mock.WithCallLimit(3))
+
+		expectedDef := mock.Definition{
+			Request:  req,
+			Response: res,
+			Context:  &mock.Context{Times: 3},
+		}
+		assert.Equal(t, expectedDef, def)
+	})
+
+	t.Run("if a context already exists, it uses that", func(t *testing.T) {
+		req := createRequest()
+		res := createResponse()
+		def := mock.NewDefinition(req, res, mock.WithCallLimit(3), mock.WithCallLimit(5))
+
+		expectedDef := mock.Definition{
+			Request:  req,
+			Response: res,
+			Context:  &mock.Context{Times: 5},
+		}
+		assert.Equal(t, expectedDef, def)
+	})
+}

--- a/mock/context_test.go
+++ b/mock/context_test.go
@@ -1,15 +1,15 @@
 package mock_test
 
-import (
-	"github.com/churmd/smockerclient/mock"
-	"github.com/stretchr/testify/assert"
-	"testing"
-)
-
-func TestNewMockCallLimit(t *testing.T) {
-	expectedContext := &mock.Context{Times: 3}
-
-	actualContext := mock.NewMockCallLimit(3)
-
-	assert.Equal(t, expectedContext, actualContext)
-}
+//func TestWithMockCallLimit(t *testing.T) {
+//	req := createRequest()
+//	res := createResponse()
+//	def := mock.NewDefinition(req, res, mock.WithCallLimit(3))
+//
+//	expectedDef := mock.Definition{
+//		Request:  req,
+//		Response: res,
+//		Context:  &mock.Context{Times: 3},
+//	}
+//
+//	assert.Equal(t, expectedDef, def)
+//}

--- a/mock/definition.go
+++ b/mock/definition.go
@@ -21,16 +21,27 @@ type Response struct {
 	Body    string              `json:"body,omitempty"`
 }
 
+type Context struct {
+	Times int `json:"times"`
+}
+
 type Definition struct {
 	Request  Request  `json:"request"`
 	Response Response `json:"response"`
+	Context  *Context `json:"context,omitempty"`
 }
 
-func NewDefinition(req Request, resp Response) Definition {
-	return Definition{
+func NewDefinition(req Request, resp Response, context *Context) Definition {
+	def := Definition{
 		Request:  req,
 		Response: resp,
 	}
+
+	if context != nil {
+		def.Context = context
+	}
+
+	return def
 }
 
 func (d Definition) ToMockDefinitionJson() ([]byte, error) {

--- a/mock/definition.go
+++ b/mock/definition.go
@@ -22,7 +22,7 @@ type Response struct {
 }
 
 type Context struct {
-	Times int `json:"times"`
+	Times int `json:"times,omitempty"`
 }
 
 type Definition struct {
@@ -31,10 +31,15 @@ type Definition struct {
 	Context  *Context `json:"context,omitempty"`
 }
 
-func NewDefinition(req Request, resp Response, context *Context) Definition {
+func NewDefinition(req Request, resp Response, contextOptions ...ContextOption) Definition {
 	def := Definition{
 		Request:  req,
 		Response: resp,
+	}
+
+	var context *Context
+	for _, fn := range contextOptions {
+		context = fn(context)
 	}
 
 	if context != nil {

--- a/mock/definition.go
+++ b/mock/definition.go
@@ -22,7 +22,7 @@ type Response struct {
 }
 
 type Context struct {
-	Times int `json:"times,omitempty"`
+	Times int `json:"times"`
 }
 
 type Definition struct {

--- a/mock/definition_test.go
+++ b/mock/definition_test.go
@@ -1,16 +1,16 @@
 package mock_test
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/churmd/smockerclient/mock"
 )
 
 func TestDefinition_ToMockJson(t *testing.T) {
-	expectedJson := `{
+	t.Run("With no Context", func(t *testing.T) {
+		expectedJson := `{
 		"request": {
 			"method": "PUT",
 			"path": "/foo/bar",
@@ -36,14 +36,57 @@ func TestDefinition_ToMockJson(t *testing.T) {
 		}
 	}`
 
-	request := createRequest()
-	response := createResponse()
-	definition := mock.NewDefinition(request, response)
+		request := createRequest()
+		response := createResponse()
+		definition := mock.NewDefinition(request, response, nil)
 
-	actualJson, err := definition.ToMockDefinitionJson()
+		actualJson, err := definition.ToMockDefinitionJson()
 
-	assert.NoError(t, err)
-	assert.JSONEq(t, expectedJson, string(actualJson))
+		assert.NoError(t, err)
+		assert.JSONEq(t, expectedJson, string(actualJson))
+	})
+
+	t.Run("With Context", func(t *testing.T) {
+		expectedJson := `{
+		"request": {
+			"method": "PUT",
+			"path": "/foo/bar",
+			"query_params": {
+			   "limit": ["10"],
+			   "filters": ["red", "green"]
+			},
+			"headers": {
+				"Content-Type": ["application/json", "application/vnd.api+json"],
+				"Authorization": ["Bearer sv2361fr1o8ph3oin"]
+			},
+			"body": {
+				"matcher": "ShouldEqualJSON",
+				"value": "{\"name\": \"John Smith\", \"uuid\": \"daa7b90d-9429-4d7a-9304-edc41ff44a6d\", \"rank\": 10}"
+			}
+		},
+		"context": {
+			"times": 3
+		},
+		"response": {
+			"status": 200,
+			"headers": {
+				"Content-Type": ["application/json"]
+			},
+			"body": "{\"status\": \"OK\"}"
+		}
+	}`
+
+		request := createRequest()
+		response := createResponse()
+		context := createContext()
+		definition := mock.NewDefinition(request, response, context)
+
+		actualJson, err := definition.ToMockDefinitionJson()
+
+		assert.NoError(t, err)
+		assert.JSONEq(t, expectedJson, string(actualJson))
+	})
+
 }
 
 func createRequest() mock.Request {
@@ -78,4 +121,8 @@ func createResponse() mock.Response {
 		Body: "{\"status\": \"OK\"}",
 	}
 	return response
+}
+
+func createContext() *mock.Context {
+	return &mock.Context{Times: 3}
 }

--- a/mock/definition_test.go
+++ b/mock/definition_test.go
@@ -38,7 +38,7 @@ func TestDefinition_ToMockJson(t *testing.T) {
 
 		request := createRequest()
 		response := createResponse()
-		definition := mock.NewDefinition(request, response, nil)
+		definition := mock.NewDefinition(request, response)
 
 		actualJson, err := definition.ToMockDefinitionJson()
 
@@ -78,8 +78,7 @@ func TestDefinition_ToMockJson(t *testing.T) {
 
 		request := createRequest()
 		response := createResponse()
-		context := createContext()
-		definition := mock.NewDefinition(request, response, context)
+		definition := mock.NewDefinition(request, response, mock.WithCallLimit(3))
 
 		actualJson, err := definition.ToMockDefinitionJson()
 
@@ -121,8 +120,4 @@ func createResponse() mock.Response {
 		Body: "{\"status\": \"OK\"}",
 	}
 	return response
-}
-
-func createContext() *mock.Context {
-	return &mock.Context{Times: 3}
 }


### PR DESCRIPTION
Adds the ability to include a Context (MockCallLimit) to mock definitions, avoiding the need for raw json definitions.

Note: this is a breaking change, so old projects would either stick to `v1.6.0` or have to include an extra `nil` parameter to their calls of `mock.NewDefinition`